### PR TITLE
Simplified and fixed ReachabilityUtility.CanReach patch

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -42,7 +42,8 @@ Thanks to everyone who's helped translate this mod!
 Thanks to everyone who's added/edited code!
 - Demonseed Elite - Refactored code for better compatibility and additional features
 - towhead - Made the fridges hide the ugliness of food
-- kbatbouta - Finding a more efficient way to keep track of what food is stored and frozen in fridges.
+- kbatbouta – Found a more efficient way to keep track of what food is stored and frozen in fridges.
+- SokyranTheDragon – Improved a Harmony patch such that it has less performance cost and is less likely to be incompatible with other mods and game updates.
 
 Many thanks go towards the original authors of this mod: Vendan, and then Kiame Vivacity.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ Thanks to everyone who's helped translate this mod!
 * Firty &amp; MrCaka - Portuguese / Brazilian
 
 Thanks to everyone who's added/edited code!
-* Demonseed Elite - Refactored code for better compatibility and additional features
-* towhead - Made the fridges hide the uglyness of food
+* Demonseed Elite – Refactored code for better compatibility and additional features.
+* towhead – Made the fridges hide the uglyness of food.
+* kbatbouta – Found a more efficient way to keep track of what food is stored and frozen in fridges.
+* SokyranTheDragon – Improved a Harmony patch such that it has less performance cost and is less likely to be incompatible with other mods and game updates.
 
 Many thanks go towards the original authors of this mod: Vendan, and then Kiame Vivacity.

--- a/Source/HarmonyPatches.cs
+++ b/Source/HarmonyPatches.cs
@@ -16,28 +16,10 @@ namespace RimFridge
     [HarmonyPatch(typeof(ReachabilityUtility), "CanReach")]
     static class Patch_ReachabilityUtility_CanReach
     {
-        static bool Prefix(ref bool __result, Pawn pawn, LocalTargetInfo dest, PathEndMode peMode, Danger maxDanger, bool canBashDoors, TraverseMode mode)
+        static void Prefix(Pawn pawn, LocalTargetInfo dest, ref PathEndMode peMode)
         {
-            try
-            {
-                if (dest.Thing?.def.category == ThingCategory.Item)
-                {
-                    foreach (Thing thing in Current.Game?.CurrentMap?.thingGrid?.ThingsAt(dest.Thing.Position))
-                    {
-                        if (thing is RimFridge_Building)
-                        {
-                            peMode = PathEndMode.Touch;
-                            __result = pawn?.Spawned == true && pawn.Map?.reachability?.CanReach(pawn.Position, dest, peMode, TraverseParms.For(pawn, maxDanger, mode, canBashDoors)) == true;
-                            return false;
-                        }
-                    }
-                }
-            }
-            catch
-            {
-                Log.Warning("RimFridge: something went wrong with CanReach check, going back to original game logic.");
-            }
-            return true;
+	        if (dest.Thing?.def.category == ThingCategory.Item && pawn?.Map != null && FridgeCache.GetFridgeCache(pawn.Map)?.HasFridgeAt(dest.Cell) == true)
+		        peMode = PathEndMode.Touch;
         }
     }
 


### PR DESCRIPTION
The changes compared to the previous code:

- The previous code was checking `CurrentMap` for the presence of the fridge, which could be different from the pawn's map - the changed code only uses pawn's map
- The previous code also ignored the `canBashFences` method argument (possibly added to the original method since the patch was written, the new patch won't have to worry about new arguments being added)
- Since the code for reachability was identical to vanilla one (with additional sanity checks for non-null pawn, pawn's map, map's reachability) with the exception of changing `peMode` - the changed code lets the vanilla method run, only changing `peMode`
- Because we let the original method run, this patch should hopefully have better compatibility with other mods patching it
- If the old code failed for whatever reason, it would let the vanilla code run - and since it called the same method with basically the same parameters it would most likely error out as well
- Instead of actually checking the map's thing grid for the presence of the fridge, the code now uses `FridgeCache` instead - since it exists already, why not use it
- Null check for the pawn is technically not necessary, as vanilla code this is a prefix to assumes it's not null - I've still included it, as the old code had this check in place

As for performance, I know the change will likely be minuscule, but from my testing/on my PC (running new and old code 1000000 each time):
- When the target category was not `Item`, the code performed ~50-100% faster (dropping the try/catch really speeds this up
- When the target category was `Item` the code performed ~25% faster (excluding the call to `Reachability.CanReach` in the old code, as I removed it when checking performance)
- When the target category was `Item` and the target cell was a full fridge (or had multiple Things in the same cell), the code performed ~25-100% faster.